### PR TITLE
Optional grace window: show the charging colour briefly after connect

### DIFF
--- a/Sources/MagHueCore/HelperConfig.swift
+++ b/Sources/MagHueCore/HelperConfig.swift
@@ -144,19 +144,25 @@ public struct HelperConfig: Codable, Equatable {
     /// Cached location for resolving sunrise/sunset anchors (set by the app).
     public var latitude: Double?
     public var longitude: Double?
+    /// Seconds to show the real charging colour after the cable is connected,
+    /// before the resolved mode takes over. 0 disables the grace window, which
+    /// keeps the previous behaviour for configs written before this key existed.
+    public var graceSeconds: Int
 
     public init(mode: LEDMode = .auto, threshold: Int = 80, chargeToFull: Bool = false,
-                schedules: [Schedule] = [], latitude: Double? = nil, longitude: Double? = nil) {
+                schedules: [Schedule] = [], latitude: Double? = nil, longitude: Double? = nil,
+                graceSeconds: Int = 0) {
         self.mode = mode
         self.threshold = min(max(threshold, 10), 100)
         self.chargeToFull = chargeToFull
         self.schedules = schedules
         self.latitude = latitude
         self.longitude = longitude
+        self.graceSeconds = min(max(graceSeconds, 0), 600)
     }
 
     enum CodingKeys: String, CodingKey {
-        case mode, threshold, chargeToFull, schedules, latitude, longitude
+        case mode, threshold, chargeToFull, schedules, latitude, longitude, graceSeconds
     }
 
     // Tolerate config files written by older versions that lack newer keys.
@@ -168,8 +174,10 @@ public struct HelperConfig: Codable, Equatable {
         let schedules = try container.decodeIfPresent([Schedule].self, forKey: .schedules) ?? []
         let latitude = try container.decodeIfPresent(Double.self, forKey: .latitude)
         let longitude = try container.decodeIfPresent(Double.self, forKey: .longitude)
+        let graceSeconds = try container.decodeIfPresent(Int.self, forKey: .graceSeconds) ?? 0
         self.init(mode: mode, threshold: threshold, chargeToFull: chargeToFull,
-                  schedules: schedules, latitude: latitude, longitude: longitude)
+                  schedules: schedules, latitude: latitude, longitude: longitude,
+                  graceSeconds: graceSeconds)
     }
 
     public static func load() -> HelperConfig {

--- a/Sources/MagHueHelper/main.swift
+++ b/Sources/MagHueHelper/main.swift
@@ -80,6 +80,8 @@ if CommandLine.arguments.contains("--probe") {
     let probeConfig = HelperConfig.load()
     print("schedules: \(probeConfig.schedules.count), location: " +
           (probeConfig.latitude != nil ? "set" : "none"))
+    print("grace window: " + (probeConfig.graceSeconds > 0
+                              ? "\(probeConfig.graceSeconds)s after connect" : "disabled"))
     if let active = probeConfig.activeSchedule(at: Date()) {
         print("active schedule now: \(active.action.displayName)")
     } else {
@@ -99,6 +101,9 @@ final class Daemon {
     private var config = HelperConfig.load()
     private var lastWritten: MagSafeLED.Color?
     private var wasOnAC = false
+    // Open while a freshly connected cable is still showing its real colour.
+    private var graceStart: Date?
+    private var graceTimer: Timer?
     private var configWatcher: DispatchSourceFileSystemObject?
 
     // Charge to Full: whether we lifted the macOS charge limit and therefore
@@ -295,18 +300,61 @@ final class Daemon {
         config = cleared
     }
 
+    // MARK: - Grace window
+
+    /// Starts the post-connect window. Writing the real colour rather than
+    /// handing back to the firmware keeps the drift check below coherent:
+    /// `system` would let the firmware set a byte we did not write, which
+    /// reads as an external change on every pass.
+    private func beginGraceWindow() {
+        guard config.graceSeconds > 0 else { return }
+        graceStart = Date()
+        graceTimer?.invalidate()
+        // The periodic pass runs every 30s, so without a dedicated timer the
+        // LED would stay lit until whenever that next came around.
+        let timer = Timer(timeInterval: Double(config.graceSeconds), repeats: false) { [weak self] _ in
+            self?.endGraceWindow()
+            self?.evaluate()
+        }
+        RunLoop.main.add(timer, forMode: .default)
+        graceTimer = timer
+        log.info("grace window open for \(self.config.graceSeconds)s")
+    }
+
+    private func endGraceWindow() {
+        graceStart = nil
+        graceTimer?.invalidate()
+        graceTimer = nil
+    }
+
     // MARK: - LED
 
     func evaluate() {
         let battery = Battery.read()
         evaluateChargeToFull(battery: battery)
-        let desired = config.resolvedColor(for: battery)
+        var desired = config.resolvedColor(for: battery)
         let onAC = battery?.onACPower ?? false
 
         // Re-assert on every re-plug even if the value is unchanged: a fresh
         // connection starts under system control.
         let force = onAC && !wasOnAC
+        if force {
+            beginGraceWindow()
+        } else if !onAC {
+            endGraceWindow()
+        }
         wasOnAC = onAC
+
+        // While the window is open, show the colour the firmware would have
+        // shown, so connecting the cable still confirms that it seated even
+        // when the resolved mode is `off`.
+        if let started = graceStart {
+            if Date().timeIntervalSince(started) < Double(config.graceSeconds) {
+                desired = (battery?.isCharged ?? false) ? .green : .amber
+            } else {
+                endGraceWindow()
+            }
+        }
 
         // Another app can rewrite the LED after us — AlDente Pro's MagSafe
         // LED feature shares this key — and writing only on change would lose


### PR DESCRIPTION
With `mode: off` the LED never lights, which also removes the one moment it is genuinely useful: confirming the magnet seated and charging started. This adds an optional grace window — on the AC-connect transition the LED shows the real charging colour (amber charging, green charged) for a configurable number of seconds, then the resolved mode takes over.

New `HelperConfig` key `graceSeconds` (Int, default 0 = disabled, clamped 0–600). Existing configs decode unchanged. The helper opens the window on the `onAC && !wasOnAC` transition, closes it on unplug or expiry via a one-shot Timer (the 30s periodic pass alone would overshoot by up to a pass), and a `--probe` line reports the setting.

Two implementation notes:

- The window writes `.amber`/`.green` explicitly rather than handing back `.system`. With ACLC = 0 the firmware writes a byte the daemon did not, which the drift check reads as an external change and reasserts every pass.
- A daemon restart while on AC also opens the window (`wasOnAC` starts false). Harmless in practice; it doubles as a visible sign the helper came back up.

Verified on two machines (Mac17,3 / macOS 26.6.1 and a desktop Apple Silicon Mac, built from this branch): unified log shows the window opening on plug-in, amber for 30.16s and 30.0s respectively, then the configured `off`. Known cosmetic: ~226ms off-then-amber flicker on connect, because the first IOPS notification can arrive before `onACPower` flips.

No UI is included; the popover control is left to the app's design. This change adds only the mechanism and the config key.
